### PR TITLE
Fix code errors

### DIFF
--- a/js/charts.js
+++ b/js/charts.js
@@ -411,10 +411,18 @@ function updateChartsTheme(theme) {
     if (!chart) return;
     
     chart.options.plugins.legend.labels.color = textColor;
-    chart.options.scales.x.ticks.color = textColor;
-    chart.options.scales.y.ticks.color = textColor;
-    chart.options.scales.x.grid.color = gridColor;
-    chart.options.scales.y.grid.color = gridColor;
+    
+    // Only update scales if they exist (pie charts don't have scales)
+    if (chart.options.scales) {
+      if (chart.options.scales.x) {
+        chart.options.scales.x.ticks.color = textColor;
+        chart.options.scales.x.grid.color = gridColor;
+      }
+      if (chart.options.scales.y) {
+        chart.options.scales.y.ticks.color = textColor;
+        chart.options.scales.y.grid.color = gridColor;
+      }
+    }
     
     chart.update();
   };
@@ -452,16 +460,16 @@ function resizeChartsForMobile() {
       chart.options.plugins.legend.labels.padding = 15;
       
       if (chart.options.scales) {
-        chart.options.scales.x.ticks.font.size = 10;
-        chart.options.scales.y.ticks.font.size = 10;
+        if (chart.options.scales.x) chart.options.scales.x.ticks.font.size = 10;
+        if (chart.options.scales.y) chart.options.scales.y.ticks.font.size = 10;
       }
     } else {
       chart.options.plugins.legend.labels.font.size = 14;
       chart.options.plugins.legend.labels.padding = 20;
       
       if (chart.options.scales) {
-        chart.options.scales.x.ticks.font.size = 12;
-        chart.options.scales.y.ticks.font.size = 12;
+        if (chart.options.scales.x) chart.options.scales.x.ticks.font.size = 12;
+        if (chart.options.scales.y) chart.options.scales.y.ticks.font.size = 12;
       }
     }
     

--- a/js/main.js
+++ b/js/main.js
@@ -176,23 +176,30 @@ function toggleTheme() {
  * Handle SIP type change
  */
 function handleSIPTypeChange() {
-  const sipType = document.getElementById('sipType').value;
+  const sipTypeElement = document.getElementById('sipType');
+  if (!sipTypeElement) return;
+  
+  const sipType = sipTypeElement.value;
   
   // Hide all conditional fields
-  document.getElementById('regularFields').classList.add('hidden');
-  document.getElementById('stepupFields').classList.add('hidden');
-  document.getElementById('flexibleFields').classList.add('hidden');
+  const regularFields = document.getElementById('regularFields');
+  const stepupFields = document.getElementById('stepupFields');
+  const flexibleFields = document.getElementById('flexibleFields');
+  
+  if (regularFields) regularFields.classList.add('hidden');
+  if (stepupFields) stepupFields.classList.add('hidden');
+  if (flexibleFields) flexibleFields.classList.add('hidden');
   
   // Show relevant fields
   switch (sipType) {
     case 'regular':
-      document.getElementById('regularFields').classList.remove('hidden');
+      if (regularFields) regularFields.classList.remove('hidden');
       break;
     case 'stepup':
-      document.getElementById('stepupFields').classList.remove('hidden');
+      if (stepupFields) stepupFields.classList.remove('hidden');
       break;
     case 'flexible':
-      document.getElementById('flexibleFields').classList.remove('hidden');
+      if (flexibleFields) flexibleFields.classList.remove('hidden');
       break;
   }
   
@@ -503,8 +510,11 @@ function showComparison() {
   displayComparisonTable(comparisonData);
   
   // Show comparison section
-  document.getElementById('comparisonSection').classList.remove('hidden');
-  document.getElementById('step3').classList.add('hidden');
+  const comparisonSection = document.getElementById('comparisonSection');
+  const step3 = document.getElementById('step3');
+  
+  if (comparisonSection) comparisonSection.classList.remove('hidden');
+  if (step3) step3.classList.add('hidden');
   
   // Update progress
   updateProgress(3);
@@ -775,7 +785,7 @@ function loadDraftData() {
     <div class="toast-content">
       <span class="toast-icon">💾</span>
       <span class="toast-message">Found saved draft from ${new Date(draft.savedAt).toLocaleDateString()}. Restore it?</span>
-      <button onclick="restoreDraft()" style="margin-left: 10px; padding: 4px 8px; background: var(--primary-500); color: white; border: none; border-radius: 4px; cursor: pointer;">Restore</button>
+      <button onclick="restoreDraft(event)" style="margin-left: 10px; padding: 4px 8px; background: var(--primary-500); color: white; border: none; border-radius: 4px; cursor: pointer;">Restore</button>
       <button onclick="clearDraft(); this.parentElement.parentElement.parentElement.remove();" style="margin-left: 5px; padding: 4px 8px; background: var(--secondary-500); color: white; border: none; border-radius: 4px; cursor: pointer;">Dismiss</button>
     </div>
   `;
@@ -793,7 +803,7 @@ function loadDraftData() {
 /**
  * Restore draft data
  */
-function restoreDraft() {
+function restoreDraft(event) {
   const draft = loadDraft();
   if (!draft) return;
   
@@ -828,9 +838,11 @@ function restoreDraft() {
   showToast('Draft restored successfully!', 'success');
   
   // Remove the toast
-  const toast = event.target.closest('.toast');
-  if (toast && toast.parentNode) {
-    toast.parentNode.removeChild(toast);
+  if (event && event.target) {
+    const toast = event.target.closest('.toast');
+    if (toast && toast.parentNode) {
+      toast.parentNode.removeChild(toast);
+    }
   }
 }
 


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Fixes multiple runtime errors by adding robust null checks for DOM elements and chart properties, and ensuring event parameters are passed correctly.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The previous implementation assumed the existence of certain DOM elements and chart scales, leading to `ReferenceError` or `TypeError` if elements were not found or if chart types (like pie charts) lacked scales. Additionally, the `restoreDraft` function attempted to use an `event` object that was not passed, causing a critical runtime error. These changes enhance the application's stability and prevent crashes in various scenarios.

---
<a href="https://cursor.com/background-agent?bcId=bc-d4c6f634-5e79-4b81-afeb-7f914a77ad4b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d4c6f634-5e79-4b81-afeb-7f914a77ad4b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>